### PR TITLE
Remove first screenshot from AppStream metadata

### DIFF
--- a/io.github.nostar.DroidStar.metainfo.xml
+++ b/io.github.nostar.DroidStar.metainfo.xml
@@ -31,9 +31,6 @@
   <url type="homepage">https://github.com/nostar/droidstar</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://i.ytimg.com/vi/nXEPDoa5FK8/maxresdefault.jpg</image>
-    </screenshot>
-    <screenshot>
       <image>https://radio.xreflector.es/wp-content/uploads/2020/11/ddd.jpg</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
It is not very useful and contains name of a YouTuber who is not associated with this project.